### PR TITLE
Conditional configMenu registration and item query handling

### DIFF
--- a/ProfitCalculator/ModEntry.cs
+++ b/ProfitCalculator/ModEntry.cs
@@ -68,7 +68,10 @@ namespace ProfitCalculator
             {
                 Monitor.Log($"Generic Mod Config Menu not found", LogLevel.Debug);
             }
-            Container.Instance.RegisterInstance(configMenu, UniqueID);
+            else
+            {
+                Container.Instance.RegisterInstance(configMenu, UniqueID);
+            }
         }
 
         private void OnGameLaunchedAddGenericModConfigMenu(object? sender, GameLaunchedEventArgs? e)


### PR DESCRIPTION
Modified `ModEntry.cs` to register `configMenu` only if it is not null, adding an `else` block for conditional registration. Introduced a new method `TryResolve` in `ShopAccessor.cs` to handle item query resolution with error logging. Adjusted `AddItemsToStock` to be conditional based on `TryResolve` results. Added detailed logging for error cases during item query resolution.